### PR TITLE
Fix bug where isPressed returns True a second time

### DIFF
--- a/src/ezButton.h
+++ b/src/ezButton.h
@@ -49,6 +49,12 @@
 #define EXTERNAL_PULLUP   0xFE
 #define EXTERNAL_PULLDOWN 0xFF
 
+enum Transition : byte {
+	NEITHER,
+	PRESSED,
+	UNPRESSED
+};
+
 class ezButton
 {
 	private:
@@ -59,9 +65,9 @@ class ezButton
 		int pressedState;     // the state when the button is considered pressed
 		int unpressedState;   // the state when the button is considered unpressed
 
-		int previousSteadyState;  // the previous steady state from the input pin, used to detect pressed and released event
-		int lastSteadyState;      // the last steady state from the input pin
+		int lastSteadyState;      // the last steady state from the input pin, used to detect pressed and released event
 		int lastFlickerableState; // the last flickerable state from the input pin
+		Transition transition;
 
 		unsigned long lastDebounceTime; // the last time the output pin was toggled
 


### PR DESCRIPTION
As currently implemented, if the button is pressed and immediately released before the next `loop` call, e.g., due to a blocking action like a `delay` call, the subsequent `loop` call will still consider the button as pressed. The same behavior occurs with unpressed when holding the button, and only momentarily releasing it.

To fix this issue, we need to do away with the `previousSteadyState` variable so that it does not require two calls to `loop` in order to change the state.

Here is an example program that demonstrates the issue:

```cpp
#include <ezButton.h>

ezButton button(14);
int count = 0;

void setup() {
  Serial.begin(9600);
  button.setDebounceTime(50);
}

void loop() {
  button.loop();
  if(button.isPressed()) {
    Serial.print(++count);
    Serial.print(" pressed");
    delay(500);
  }
  else if(button.isReleased()) {
    Serial.println(" released");
    delay(500);
  }  
}
```

The output produced looks like:
```
23:52:08.656 -> 1 pressed2 pressed released
23:52:11.361 -> 3 pressed4 pressed released
23:52:13.805 -> 5 pressed6 pressed released
23:52:16.183 -> 7 pressed8 pressed released
```

With this fix in place the output looks as expected:
```
23:54:25.883 -> 1 pressed released
23:54:27.468 -> 2 pressed released
23:54:28.688 -> 3 pressed released
23:54:29.877 -> 4 pressed released
23:54:30.996 -> 5 pressed released
```

I believe this pull request may resolve #10, #12, and possibly #8.